### PR TITLE
🔧 Updated dwForceAttack2 signature

### DIFF
--- a/config.json
+++ b/config.json
@@ -154,7 +154,7 @@
     },
     {
       "name": "dwForceAttack2",
-      "extra": 36,
+      "extra": 12,
       "relative": true,
       "module": "client.dll",
       "offsets": [


### PR DESCRIPTION
Valve probably decided to undo their changes to dwForceAttack2. The "extra" offset is now 0xC again. Grabbed and tested the extra offset by myself.

![Unbenannt](https://user-images.githubusercontent.com/57193602/148102653-b6e84cd3-cdb1-4f05-9550-01e4a8bb85e5.PNG)

